### PR TITLE
fix(nx-vercel,nx-bitbucket-server): read nx.json manually instead of …

### DIFF
--- a/packages/nx-bitbucket-server/src/executors/pr-comment/executor.ts
+++ b/packages/nx-bitbucket-server/src/executors/pr-comment/executor.ts
@@ -16,9 +16,7 @@ const runExecutor: Executor<PrCommentExecutorSchema> = async (
   context
 ) => {
   const { message, sticky } = options;
-  const { projectKey, repositorySlug, baseUrl } = getPluginConfig(
-    context.workspace
-  );
+  const { projectKey, repositorySlug, baseUrl } = getPluginConfig(context);
   const prNumber =
     typeof options.prNumber === 'string'
       ? Number.parseInt(options.prNumber)

--- a/packages/nx-bitbucket-server/src/utils/plugin-config.ts
+++ b/packages/nx-bitbucket-server/src/utils/plugin-config.ts
@@ -1,4 +1,4 @@
-import { NxJsonConfiguration } from '@nrwl/devkit';
+import { ExecutorContext } from '@nrwl/devkit';
 import PluginConfigSchema = require('./plugin-config-schema.json');
 import { getPluginConfig as getPluginConfigOriginal } from '@nx-expand/utilities';
 
@@ -8,9 +8,9 @@ export type PluginConfig = {
   repositorySlug: string;
 };
 
-export const getPluginConfig = (nxConfig: NxJsonConfiguration) =>
+export const getPluginConfig = (context: ExecutorContext) =>
   getPluginConfigOriginal<PluginConfig>(
-    nxConfig,
+    context,
     'nx-bitbucket-server',
     PluginConfigSchema
   );

--- a/packages/nx-vercel/src/executors/deploy-prebuilt/executor.ts
+++ b/packages/nx-vercel/src/executors/deploy-prebuilt/executor.ts
@@ -13,7 +13,7 @@ import {
 const runExecutor: ExecutorWithPostTargets<
   DeployPrebuiltExecutorSchema
 > = async (options, context) => {
-  const { vercelCommand = 'vercel' } = getPluginConfig(context.workspace);
+  const { vercelCommand = 'vercel' } = getPluginConfig(context);
 
   if (!context.projectName) {
     throw new Error('nx-vercel requires projectName to be assigned');

--- a/packages/nx-vercel/src/executors/pull/executor.ts
+++ b/packages/nx-vercel/src/executors/pull/executor.ts
@@ -46,7 +46,7 @@ async function copyEnvironmentFile(
 }
 
 const runExecutor: Executor<PullExecutorSchema> = async (options, context) => {
-  const { vercelCommand = 'vercel' } = getPluginConfig(context.workspace);
+  const { vercelCommand = 'vercel' } = getPluginConfig(context);
 
   if (!context.projectName) {
     throw new Error('nx-vercel requires projectName to be assigned');

--- a/packages/nx-vercel/src/utils/plugin-config.ts
+++ b/packages/nx-vercel/src/utils/plugin-config.ts
@@ -1,4 +1,4 @@
-import { NxJsonConfiguration } from '@nrwl/devkit';
+import { ExecutorContext } from '@nrwl/devkit';
 import PluginConfigSchema = require('./plugin-config-schema.json');
 import { getPluginConfig as getPluginConfigOriginal } from '@nx-expand/utilities';
 
@@ -10,9 +10,9 @@ export interface PluginConfig {
   vercelCommand?: string;
 }
 
-export const getPluginConfig = (nxConfig: NxJsonConfiguration) =>
+export const getPluginConfig = (context: ExecutorContext) =>
   getPluginConfigOriginal<PluginConfig>(
-    nxConfig,
+    context,
     'nx-vercel',
     PluginConfigSchema
   );

--- a/packages/utilities/src/lib/plugin-config.ts
+++ b/packages/utilities/src/lib/plugin-config.ts
@@ -1,4 +1,9 @@
-import { NxJsonConfiguration } from '@nrwl/devkit';
+import {
+  ExecutorContext,
+  joinPathFragments,
+  NxJsonConfiguration,
+  readJsonFile,
+} from '@nrwl/devkit';
 import {
   setDefaults,
   validateOptsAgainstSchema,
@@ -8,10 +13,13 @@ import {
 } from 'nx/src/utils/params';
 
 export function getPluginConfig<T>(
-  nxConfig: NxJsonConfiguration,
+  context: ExecutorContext,
   pluginName: string,
   schema: Schema
 ): T {
+  const nxConfig = readJsonFile<NxJsonConfiguration>(
+    joinPathFragments(context.root, 'nx.json')
+  );
   const pluginConfig = (nxConfig.pluginsConfig?.[pluginName] ?? {}) as Record<
     string,
     unknown


### PR DESCRIPTION
…relying on executor context

After Nx v14.4.0, the executor context no longer includes the nx.json configuration. This is tracked
in https://github.com/nrwl/nx/issues/11205 but it doesn't seem to get any attention and it's still
an issue in v14.6.4, hence we now read the config manually.